### PR TITLE
Update dependencies and use new method for event subscriptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["jazzfool"]
 edition = "2018"
 
 [dependencies]
-iced = { version = "0.2", features = ["image", "tokio"] } 
+iced = { git = "https://github.com/hecrj/iced.git", features = ["image", "tokio"] } 
 iced_native = "0.3.0"
 gstreamer = "0.16" 
 gstreamer-app = "0.16" # appsink 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["jazzfool"]
 edition = "2018"
 
 [dependencies]
-iced = { version = "0.1", features = ["image", "tokio"] } 
+iced = { version = "0.2", features = ["image", "tokio"] } 
 iced_native = "0.2" 
 gstreamer = "0.16" 
 gstreamer-app = "0.16" # appsink 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 
 [dependencies]
 iced = { version = "0.2", features = ["image", "tokio"] } 
-iced_native = "0.2" 
+iced_native = "0.3.0"
 gstreamer = "0.16" 
 gstreamer-app = "0.16" # appsink 
 glib = "0.10" # gobject traits and error type
-tokio = { version = "0.2", features = ["time", "stream"] }# time subscription (every frame)          
+tokio = { version = "1.2.0", features = ["time"] }
 thiserror = "1" 
 url = "2" # media uri
 num-rational = "0.3" # framerates come in rationals

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,36 +353,7 @@ impl VideoPlayer {
 
 // until iced 0.2 is released, which has this built-in
 mod time {
-    use iced::futures;
-
     pub fn every(duration: std::time::Duration) -> iced::Subscription<std::time::Instant> {
-        iced::Subscription::from_recipe(Every(duration))
-    }
-
-    struct Every(std::time::Duration);
-
-    impl<H, I> iced_native::subscription::Recipe<H, I> for Every
-    where
-        H: std::hash::Hasher,
-    {
-        type Output = std::time::Instant;
-
-        fn hash(&self, state: &mut H) {
-            use std::hash::Hash;
-
-            std::any::TypeId::of::<Self>().hash(state);
-            self.0.hash(state);
-        }
-
-        fn stream(
-            self: Box<Self>,
-            _input: futures::stream::BoxStream<'static, I>,
-        ) -> futures::stream::BoxStream<'static, Self::Output> {
-            use futures::stream::StreamExt;
-
-            tokio::time::interval(self.0)
-                .map(|_| std::time::Instant::now())
-                .boxed()
-        }
+	iced::time::every(duration)
     }
 }


### PR DESCRIPTION
First off, thanks for the project! It looks very useful, but I had to make some changes for it to compile with the project. 
1. Updated iced from 0.1 to the latest version on the Git with other dependencies
2. Change event subscriptions to use a provided event

I attempted to use the latest published version, but there was a native library incompatibility that prevented this. If pulling the latest version from the Git isn't a reasonable default, then I can change that as well.