### PR TITLE
Add non-str pipeline support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "iced_video_player"
-version = "0.1.3"
+version = "0.3.0"
 dependencies = [
  "glib",
  "gstreamer",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //! use iced_video_player::{Video, VideoPlayer};
 //! use iced::{Sandbox, Element};
 //!
+//! # #![allow(clippy::needless_doctest_main)]
 //! fn main() {
 //!     App::run(Default::default());
 //! }

--- a/src/video.rs
+++ b/src/video.rs
@@ -121,10 +121,7 @@ impl Video {
     /// Expects an appsink plugin to be present with name set to `iced_video` and caps to
     /// `video/x-raw,format=RGBA,pixel-aspect-ratio=1/1`
     pub fn from_pipeline<S: AsRef<str>>(pipeline: S, is_live: Option<bool>) -> Result<Self, Error> {
-        if !gst::INITIALIZED.load(Ordering::SeqCst) {
-            gst::init()?;
-        }
-
+        gst::init()?;
         let pipeline = gst::parse::launch(pipeline.as_ref())?
             .downcast::<gst::Pipeline>()
             .map_err(|_| Error::Cast)?;
@@ -139,11 +136,9 @@ impl Video {
         pipeline: gst::Pipeline,
         is_live: Option<bool>,
     ) -> Result<Self, Error> {
+        gst::init()?;
         static NEXT_ID: AtomicU64 = AtomicU64::new(0);
         let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
-        if !gst::INITIALIZED.load(Ordering::SeqCst) {
-            gst::init()?;
-        }
 
         let mut live = false;
 


### PR DESCRIPTION
Fun fact - Raspberry Pi 5 Vulkan implementation limits texture size to 2048. And as far as I understand this lib allocates a texture based on video source size, not on the size of output widget, which I guess makes sense due to resizing requirements. But the result is that trying to use 4k camera causes iced to panic.
My solution? Query resolutions that are provided by camera and select highest one below 2048 in both dimensions. But to do that, I need access to GStreamer elements, so here is the PR.