### PR TITLE
Prevent going out of bounds with ContentFit::None

### DIFF
--- a/src/video_player.rs
+++ b/src/video_player.rs
@@ -192,16 +192,24 @@ where
             inner.set_av_offset(Instant::now() - last_frame_time);
         }
 
-        renderer.draw_primitive(
-            drawing_bounds,
-            VideoPrimitive::new(
-                inner.id,
-                Arc::clone(&inner.alive),
-                Arc::clone(&inner.frame),
-                (inner.width as _, inner.height as _),
-                upload_frame,
-            ),
-        );
+        let render = |renderer: &mut Renderer| {
+            renderer.draw_primitive(
+                drawing_bounds,
+                VideoPrimitive::new(
+                    inner.id,
+                    Arc::clone(&inner.alive),
+                    Arc::clone(&inner.frame),
+                    (inner.width as _, inner.height as _),
+                    upload_frame,
+                ),
+            );
+        };
+
+        if adjusted_fit.width > bounds.width || adjusted_fit.height > bounds.height {
+            renderer.with_layer(bounds, render);
+        } else {
+            render(renderer);
+        }
     }
 
     fn on_event(


### PR DESCRIPTION
With `ContentFit::None`, the video overlaps elements that aren't in its designated space:

| `ContentFit::Contain` | `ContentFit::None` (before) | `ContentFit::None` (after) |
| - | - | - |
| ![Screenshot 2024-12-03 234515](https://github.com/user-attachments/assets/b7d22f8d-c039-4d90-8e1d-40ece6682a42) | ![Screenshot 2024-12-03 234559](https://github.com/user-attachments/assets/bb81b3ae-f836-4e9a-a224-be756912e480) | ![Screenshot 2024-12-03 234540](https://github.com/user-attachments/assets/641235ca-3653-4b27-948f-49bb21f22470) |

I've adjusted the behavior to be in line with Iced's `Image` widget: https://github.com/iced-rs/iced/blob/9c9334108901951716c020d585ce3deef3127a89/widget/src/image.rs#L206-L225 . You can see in the Iced `ferris` example that, even with `ContentFit::None`, the image stays in its box:

> ![Screenshot 2024-12-03 234801](https://github.com/user-attachments/assets/d1fb0f5b-1ffa-484e-83e8-0b3d9096d144)
