### PR TITLE
don't panic in Drop when video worker thread panics

### DIFF
--- a/src/video.rs
+++ b/src/video.rs
@@ -189,7 +189,12 @@ impl Drop for Video {
 
         inner.alive.store(false, Ordering::SeqCst);
         if let Some(worker) = inner.worker.take() {
-            worker.join().expect("failed to stop video thread");
+            if let Err(err) = worker.join() {
+                match err.downcast_ref::<String>() {
+                    Some(e) => log::error!("Video thread panicked: {e}"),
+                    None => log::error!("Video thread panicked with unknown reason"),
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
I've been having issues with the video thread panicking when using some unstable network streams, resulting in the main thread to also panic. This patch just logs the panic message and that's it.

By the way, thank you for this library, it's great!